### PR TITLE
スケジュール削除

### DIFF
--- a/app/src/main/java/calendar/reserve/app/controllers/ScheduleController.java
+++ b/app/src/main/java/calendar/reserve/app/controllers/ScheduleController.java
@@ -26,8 +26,6 @@ public class ScheduleController {
                 try {
                     JsonNode node = mapper.readTree(req.body());
                     String schedule_id = scheduleService.create(node.get("user_email").textValue(), node.get("day").textValue(), node.get("title").textValue(), "xx"); // TODO: reserve_id が ""のときも対応
-                    System.out.println("okkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk");
-                    System.out.println(schedule_id);
                     res.status(200);
                     res.type("application/json");
                     return scheduleService.getById(node.get("user_email").textValue(), schedule_id);
@@ -38,12 +36,22 @@ public class ScheduleController {
                 }
             }, jsonTransformer);
 
+            post("/delete_schedule", (req, res) -> {
+                try {
+                    JsonNode node = mapper.readTree(req.body());
+                    scheduleService.destroy(node.get("schedule_id").textValue());
+                    res.status(200);
+                    res.type("application/json"); 
+                    return "ok";
+                } catch (Exception e) {
+                    ErrorMessage em = new ErrorMessage(e.getMessage());
+                    res.status(400);
+                    return em;
+                }
+            }, jsonTransformer);
+
             post("/calender", (req, res) -> {
                 try {
-                    System.out.println("okkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk");
-                    Logger logger = LoggerFactory.getLogger("root");
-                    logger.info("test operation info");
-                    logger.error("test operation error");
                     JsonNode node = mapper.readTree(req.body());
                     res.status(200);
                     res.type("application/json");

--- a/app/src/main/java/calendar/reserve/app/models/Remain.java
+++ b/app/src/main/java/calendar/reserve/app/models/Remain.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 public class Remain implements Serializable {
 
     private static final long serialVersionUID = 2L;// ここの値はuserと変えるべきか
-	public static final String ID = "id";
+	public static final String ID = "remain_id";
 	public static final String DAY = "day";
 	public static final String REMAIN_NUM = "remain_num_of_people";
     public static final String EVENT_ID= "event_id";

--- a/app/src/main/java/calendar/reserve/app/models/Reserve.java
+++ b/app/src/main/java/calendar/reserve/app/models/Reserve.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 public class Reserve implements Serializable {
 
     private static final long serialVersionUID = 2L;// ここの値はuserと変えるべきか
-	public static final String ID = "id";
+	public static final String ID = "reserve_id";
 	public static final String EMAIL = "user_email";
 	public static final String REMAIN_ID = "remain_id";
 

--- a/app/src/main/java/calendar/reserve/app/services/ScheduleService.java
+++ b/app/src/main/java/calendar/reserve/app/services/ScheduleService.java
@@ -75,9 +75,7 @@ public class ScheduleService extends ModelService {
        DistributedTransaction tx = manager.start();
 
         try {
-            Get get =
-					// new Get(new Key(Schedule.USER_EMAIL, user_email), new Key(Schedule.DAY, "2022-07-11", Schedule.SCHEDULE_ID, schedule_id))  
-                    new Get(new Key(Schedule.SCHEDULE_ID, schedule_id))                              
+            Get get = new Get(new Key(Schedule.SCHEDULE_ID, schedule_id))                              
 					.forNamespace(NAMESPACE)               
 					.forTable(TABLE_NAME);
 

--- a/app/src/main/java/calendar/reserve/app/utils/ScalarUtil.java
+++ b/app/src/main/java/calendar/reserve/app/utils/ScalarUtil.java
@@ -7,6 +7,10 @@ public class ScalarUtil  {
 
     public static String getTextValue(Optional<Result> result, String field_name) {
         return result.get().getValue(field_name).get().getAsString().get();
+    }
+
+    public static int getIntValue(Optional<Result> result, String field_name) {
+        return result.get().getValue(field_name).get().getAsInt();
     }   
 
     public static Boolean getBooleanValue(Optional<Result> result, String field_name) {
@@ -16,6 +20,10 @@ public class ScalarUtil  {
 
     public static String getResultTextValue(Result result, String field_name) {
         return result.getValue(field_name).get().getAsString().get();
+    }   
+
+     public static int getResultIntValue(Result result, String field_name) {
+        return result.getValue(field_name).get().getAsInt();
     }   
 
     public static Boolean getResultBooleanValue(Result result, String field_name) {


### PR DESCRIPTION
スケジュール削除を，`ScheduleService.destroy` らへんに実装しました．
`ScheduleService.destroy`  の内容としてはこんな感じです．

1. 削除対象のScheduleをGet
2. 削除対象のReserveをGet
3. 削除対象のReserveをDelete
4. Reserve に紐づくRemainのremain_num_of_people を+1
5. 削除対象のScheduleをDelete

※ 2, 3, 4 は，削除対象のScheduleがReserveに紐づいている場合のみ実行．Scheduleのreserve_idが`xx` になってる場合は，紐づいてない（カレンダーから追加したSchedule）．

※ Delete について

- secondary-indexだけだと削除できないっぽい
partition-key, clustering-key を全て Delete 内で指定しないと削除できないっぽい．
- Delete の前に，Get しないと削除できないっぽい．
Delete で指定するのと同じ key で，Deleteする前にGetしないと削除できないっぽい．
そのため，以下のような感じで書いた．
```
// Delete の前にGetする必要あり
// Delete と同じように，partition-key, clustering-key を指定
Get getScheduleForDelete =
                    new Get(
                        new Key(Schedule.USER_EMAIL, userEmail),
                        new Key(Schedule.DAY, scheduleDay, Schedule.SCHEDULE_ID, scheduleId, Schedule.RESERVE_ID, reserveId)
                    )                              
		   .forNamespace(NAMESPACE)               
		   .forTable(TABLE_NAME);
getResultAndThrowsIfNotFound(tx, getScheduleForDelete, "スケジュール");
Delete delete = 
                new Delete(
                        new Key(Schedule.USER_EMAIL, userEmail),
                        new Key(Schedule.DAY, scheduleDay, Schedule.SCHEDULE_ID, scheduleId, Schedule.RESERVE_ID, reserveId)
                    )
                   .forNamespace(NAMESPACE)               
		   .forTable(TABLE_NAME);
tx.delete(delete);
```

※ リクエストが成功した場合
<img width="1440" alt="スクリーンショット 2022-07-18 18 03 41" src="https://user-images.githubusercontent.com/63027348/179478950-3598353c-7e0c-467f-ba80-b341da810114.png">

