### PR TITLE
add delete function from reservation site

### DIFF
--- a/app/src/main/java/calendar/reserve/app/controllers/ReservationController.java
+++ b/app/src/main/java/calendar/reserve/app/controllers/ReservationController.java
@@ -69,6 +69,23 @@ public class ReservationController {
                 }
             });
 
+            post("/delete_reserve", (req, res) -> {
+                try {
+                    String json = req.body();
+                    ObjectMapper mapper = new ObjectMapper();
+                    JsonNode node = mapper.readTree(json);
+                    String reserve_id = node.get("reserve_id").textValue();
+                    res.type("application/json");
+
+                    return reservationservice.destroy(reserve_id);
+                } catch (Exception e) {
+                    ErrorMessage em = new ErrorMessage(e.getMessage());
+                    res.status(400);
+                    return em;
+                }
+            });
+
+
 
             exception(Exception.class, (exception, request, response) -> {
                 response.type("application/json");


### PR DESCRIPTION
## やったこと
`ReserveService.destroy`に予約サイトからのスケジュール削除を追加
## DB制御手順
1. 削除対象のReserveをGet
2. 削除対象のRemainをGet
3. 削除対象のReserveをDelete
4. 削除対象のScheduleをScanで取得（同日のスケジュール一覧からreserve_idで選択）
5. 削除対象のScheduleをDelete

## API Request
- Endpoint: "/delete_reserve"
- 成功時
<img width="1513" alt="スクリーンショット 2022-07-18 23 23 00" src="https://user-images.githubusercontent.com/79315807/179532739-e55e3df4-267f-4dca-85d8-bc9c36290c94.png">
